### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = "./mysh"

--- a/README.md
+++ b/README.md
@@ -162,3 +162,5 @@ Test your shell by running the following commands in it (in order):
 
     pid                                        ; zombie avoidance checking
     /bin/ps -lfu USERNAME | grep defunct       ; replace USERNAME with your username
+
+    [![Run on Repl.it](https://repl.it/badge/github/michaeli-g/OS-Shell)](https://repl.it/github/michaeli-g/OS-Shell)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).